### PR TITLE
Update subsets.js added missing is_counterpart

### DIFF
--- a/src/catalogItem/subsets.js
+++ b/src/catalogItem/subsets.js
@@ -26,6 +26,8 @@ export class SubsetEntry {
     this.extra_quantity = data.extra_quantity || 0;
     /** @type {boolean} */
     this.is_alternate = data.is_alternate || false;
+    /** @type {boolean} */
+    this.is_counterpart = data.is_counterpart || false;
   }
 }
 /**


### PR DESCRIPTION
I ran into as missing field from the subset api and needed it.
This patch will fix it. 2 lines added. 